### PR TITLE
add srcDir and  outDir options

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ Default options:
     ".jpg",
     ".png",
     ".svg"
-  ]
+  ],
+  "srcDir": ".",
+  "outDir": "."
 }
 ```
 
@@ -73,6 +75,12 @@ import image from './path/to/icon.png';
 
 const image = '/static/icon-[hash].png';
 ```
+
+### srcDir / outDir
+
+If you are using a compiler like Typescript and compiling your Typescript sources to a
+different location it also needs to get the images from the sort location. Use `srcDir` and `outDir`
+to control the path replacement. 
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ Default options:
     ".png",
     ".svg"
   ],
-  "srcDir": ".",
-  "outDir": "."
+  "srcDir": "",
+  "outDir": ""
 }
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,6 @@ const applyTransform = (p, t, state, value, calleeName) => {
 
   if (options.extensions && options.extensions.indexOf(ext) >= 0) {
     const dir = dirname(resolve(state.file.opts.filename));
-    const root = state.file.opts.sourceRoot || process.cwd();
     let absPath = resolve(dir, value);
 
     if (options.baseDir) {
@@ -28,6 +27,7 @@ const applyTransform = (p, t, state, value, calleeName) => {
     }
 
     if(options.srcDir && options.outDir) {
+      const root = state.file.opts.sourceRoot || process.cwd();
       const srcPath = resolve(root, options.srcDir);
       const outPath = resolve(root, options.outDir);
       absPath = absPath.replace(outPath, srcPath);

--- a/src/index.js
+++ b/src/index.js
@@ -20,10 +20,17 @@ const applyTransform = (p, t, state, value, calleeName) => {
 
   if (options.extensions && options.extensions.indexOf(ext) >= 0) {
     const dir = dirname(resolve(state.file.opts.filename));
-    const absPath = resolve(dir, value);
+    const root = state.file.opts.sourceRoot || process.cwd();
+    let absPath = resolve(dir, value);
 
     if (options.baseDir) {
       options.baseDir = options.baseDir.replace(/[\/\\]+/g, path.sep);
+    }
+
+    if(options.srcDir && options.outDir) {
+      const srcPath = resolve(root, options.srcDir);
+      const outPath = resolve(root, options.outDir);
+      absPath = absPath.replace(outPath, srcPath);
     }
 
     transform(p, t, state, options, absPath, calleeName);

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ const applyTransform = (p, t, state, value, calleeName) => {
       options.baseDir = options.baseDir.replace(/[\/\\]+/g, path.sep);
     }
 
-    if(options.srcDir && options.outDir) {
+    if (options.srcDir && options.outDir) {
       const root = state.file.opts.sourceRoot || process.cwd();
       const srcPath = resolve(root, options.srcDir);
       const outPath = resolve(root, options.outDir);

--- a/src/transform.js
+++ b/src/transform.js
@@ -23,7 +23,7 @@ function getFile(state, absPath, opts) {
 
   if (opts.baseDir) {
     file = path.sep + path.join(opts.baseDir, file).replace(/^[\/\\]+/, '')
-    fs.copySync(absPath, path.join(root, file))
+    fs.copySync(absPath, path.join(root, opts.outDir || '', file))
   }
 
   return '/' + file


### PR DESCRIPTION
I'm using next.js with Typescript and my babel input is located in the Typescript output folder. The image files still reside in the src folder in that case and therefore can't be found. I added the two options to specify those paths and also be able to resolve those files.